### PR TITLE
Fix webpack config and add express dependency for DO deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "express": "^4.18.2",
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,9 +10,7 @@ module.exports = (env, argv) => {
       filename: 'bundle.js',
       path: path.resolve(__dirname, 'dist'),
       clean: true,
-      publicPath: process.env.NODE_ENV === 'production' 
-      ? '/sophie-agent/'  // Must match your repo name
-      : '/',
+      publicPath: '/',
     },
     mode: argv.mode,
     devtool: isProduction ? 'source-map' : 'inline-source-map',


### PR DESCRIPTION
This PR includes the following changes to fix the DigitalOcean deployment:

1. Renamed webpack-config.js to webpack.config.js to match package.json scripts
2. Simplified publicPath configuration to use root path
3. Added express as a production dependency for the server

These changes should resolve the blank page issue in the DigitalOcean deployment.